### PR TITLE
Fix editable plugin path

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <!-- Leaflet JS (no integrity or crossorigin) -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <!-- Plugin for editing geometries -->
-  <script src="https://unpkg.com/leaflet-editable@1.2.0/src/Leaflet.Editable.js"></script>
+  <script src="https://unpkg.com/leaflet-editable@1.2.0/dist/leaflet-editable.js"></script>
   <script>
     // basemap layers
     var baseLayers = {


### PR DESCRIPTION
## Summary
- use `dist/leaflet-editable.js` instead of `src/Leaflet.Editable.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68725bf36abc8321b5aa3719480505e5