### PR TITLE
Fix leaflet editable path, default light basemap, UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,14 +23,15 @@
     #basemap-select,
     #geojson-input {
       font-size: 1.2em;
+      font-family: inherit;
     }
   </style>
 </head>
 <body>
   <!-- basemap selector -->
   <select id="basemap-select" style="position:absolute;top:10px;right:10px;z-index:1000;">
+    <option value="light" selected>Light</option>
     <option value="dark">Dark</option>
-    <option value="light">Light</option>
   </select>
 
   <!-- geojson uploader -->
@@ -42,7 +43,7 @@
   <!-- Leaflet JS (no integrity or crossorigin) -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <!-- Plugin for editing geometries -->
-  <script src="https://unpkg.com/leaflet-editable@1.2.0/dist/leaflet-editable.js"></script>
+  <script src="https://unpkg.com/leaflet-editable@1.2.0/src/Leaflet.Editable.js"></script>
   <script>
     // basemap layers
     var baseLayers = {
@@ -56,15 +57,15 @@
       })
     };
 
-    // initialize the map with the dark basemap
+    // initialize the map with the light basemap
     var map = L.map('map', {
       editable: true,
       center: [40, -100],
       zoom: 4,
-      layers: [baseLayers.dark]
+      layers: [baseLayers.light]
     });
 
-    var currentLayer = baseLayers.dark;
+    var currentLayer = baseLayers.light;
     var uploadedLayer;
 
     // handle basemap selector


### PR DESCRIPTION
## Summary
- fix plugin path for Leaflet.Editable to load correctly
- default to the light basemap and update selector
- ensure basemap select font matches upload field

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68725ff9fe5083218a99284cad6aa1cf